### PR TITLE
Typo + #include <fcntl.h>

### DIFF
--- a/C/ADXL345.c
+++ b/C/ADXL345.c
@@ -10,7 +10,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 
-void main() 
+int main() 
 {
 	// Create I2C bus
 	int file;
@@ -48,7 +48,7 @@ void main()
 	char data[6] ={0};
 	if(read(file, data, 6) != 6)
 	{
-		printf("Erorr : Input/output Erorr \n");
+		printf("Error : Input/output Error \n");
 		exit(1);
 	}
 	else
@@ -77,4 +77,6 @@ void main()
 		printf("Acceleration in Y-Axis : %d \n", yAccl);
 		printf("Acceleration in Z-Axis : %d \n", zAccl);
 	}
+	
+	return 0;
 }


### PR DESCRIPTION
Without #include <fcntl.h> I get errors like:
```
Code.c: In function ‘main’:
Code.c:31:2: warning: implicit declaration of function ‘write’ [-Wimplicit-function-declaration]
  write(file, config, 2);
  ^~~~~
Code.c:42:2: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
  sleep(1);
  ^~~~~
Code.c:49:5: warning: implicit declaration of function ‘read’ [-Wimplicit-function-declaration]
  if(read(file, data, 6) != 6)
     ^~~~
gcc -Wall Code.c -o Code -lwiringPi
Code.c: In function ‘main’:
Code.c:31:2: warning: implicit declaration of function ‘write’ [-Wimplicit-function-declaration]
  write(file, config, 2);
  ^~~~~
Code.c:42:2: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
  sleep(1);
  ^~~~~
Code.c:49:5: warning: implicit declaration of function ‘read’ [-Wimplicit-function-declaration]
  if(read(file, data, 6) != 6)
```